### PR TITLE
ci: conditional linting on ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         node-version: [ 16, 18, 20 ]
-        os: [ubuntu-20.04, ubuntu-22.04, windows-latest, macos-12, macos-11]
+        os: [ubuntu-22.04, ubuntu-20.04, windows-latest, macos-12, macos-11]
 
     runs-on: ${{ matrix.os }}
 
@@ -36,6 +36,7 @@ jobs:
     - name: Install dependencies
       run: pnpm install
     - name: Run Linters
+      if: ${{ matrix.os == 'ubuntu-22.04' }}
       run: pnpm lint
     - name: Build Library
       run: pnpm build


### PR DESCRIPTION
This commit intends to lighten up the CI process by only running the linter when the operating system is 'ubuntu-22.04', as that step does not really affect runtime behavior, nor the build process.