### PR TITLE
docs: use absolute url for readme image

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
 <img
-  src="docs/example1.svg"
+  src="https://raw.githubusercontent.com/Coder-Spirit/beautiful-tree/main/docs/example1.svg"
 	style="height:300px;width:300px;"
 	alt="Tree rendered with BeautifulTree"
 />


### PR DESCRIPTION
Use absolute url for README image, so it can be displayed in the NPM site.